### PR TITLE
fix(remote-kernels): SSH wait, watchdog gate, stale volume lease, startup reconcile (#97–#100)

### DIFF
--- a/crates/remote-kernels/scripts/machine/rk-lease.sh
+++ b/crates/remote-kernels/scripts/machine/rk-lease.sh
@@ -43,6 +43,22 @@ json_uint() {
     sed -n "s/.*\"${key}\":\([0-9][0-9]*\).*/\1/p" "$lease_file"
 }
 
+# A finalizing lease binds only while the process that entered it can still
+# finish it: the watchdog recorded in watchdog.pid on THIS machine. The state
+# directory may live on a persistent volume (RunPod network volumes are
+# mounted at the workdir), so a pod that died mid-finalize leaves a finalizing
+# lease that every later pod mounting the volume would otherwise inherit as
+# "running its automatic cleanup" -- with no process anywhere able to clear
+# it. No live finalizer here means the lease is a fossil, not an operation.
+finalizer_alive() {
+    local pid_file="$state_dir/watchdog.pid" pid=""
+    [ -f "$pid_file" ] || return 1
+    pid=$(tr -cd "0-9" < "$pid_file")
+    is_uint "$pid" || return 1
+    kill -0 "$pid" 2>/dev/null || return 1
+    tr "\0" " " < "/proc/$pid/cmdline" 2>/dev/null | grep -q "rk-watchdog"
+}
+
 load_lease() {
     if [ ! -f "$lease_file" ]; then
         generation=0
@@ -134,7 +150,13 @@ load_lease
 case "$op" in
     acquire)
         [ "$#" -eq 1 ] && is_atom "$1" || fail_invalid "usage: acquire <owner_uuid>"
-        [ "$state" != "finalizing" ] || exit "$EXIT_REFUSED"
+        if [ "$state" = "finalizing" ]; then
+            finalizer_alive && exit "$EXIT_REFUSED"
+            # Stale finalize from a machine that no longer exists: its
+            # outcome marker would block the finalize of this machine.
+            rm -f "$state_dir/outcome.json" "$state_dir/watchdog.pid"
+            printf "%s\n" "reclaimed a finalizing lease with no live finalizer (op ${op_id:-?}, action ${action:-?})" >&2
+        fi
         pause_after_read_for_test
         generation=$((generation + 1))
         owner_uuid="$1"

--- a/crates/remote-kernels/src/heartbeat.rs
+++ b/crates/remote-kernels/src/heartbeat.rs
@@ -55,6 +55,9 @@ pub enum AcquireMode {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SupervisionStatus {
     Pending,
+    /// Lease held and watchdog installed (budget enforceable); startup
+    /// commands may still be running.
+    Supervised,
     Active,
     Unsupervisable(String),
     Refused(String),
@@ -278,8 +281,11 @@ async fn establish_and_run(
     }
     // All setup writes happen only after acquiring authority and while the
     // local operation lock prevents another project server from rotating it.
-    run_startup_commands(conn, machine_id, startup_commands).await;
-
+    // Startup commands run AFTER the watchdog is installed (below): the
+    // server treats an unconfirmed watchdog as an unenforceable budget and
+    // terminates the machine, so anything slow in front of the install --
+    // a package install, even a 1 s installer on a slow host -- used to end
+    // the machine before it could be used.
     let budget = budget.map(|budget| BudgetFeed {
         state: Arc::clone(state),
         budget,
@@ -338,6 +344,8 @@ async fn establish_and_run(
             "Could not clear inherited budget deadline: {e:#}"
         );
     }
+    let _ = status.send(SupervisionStatus::Supervised);
+    run_startup_commands(conn, machine_id, startup_commands).await;
     let _ = status.send(SupervisionStatus::Active);
     drop(operation_lock);
 

--- a/crates/remote-kernels/src/main.rs
+++ b/crates/remote-kernels/src/main.rs
@@ -87,14 +87,21 @@ async fn serve(project_dir: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
     let server = server::RemoteKernelsServer::new_with_budget(config, app_state, budget);
     let shutdown_server = server.clone();
 
-    let reconcile_messages = server.reconcile().await;
-    for message in &reconcile_messages {
-        tracing::info!("{message}");
-    }
-    // Startup reconcile findings surface via status(), and this session's
-    // running machines are picked back up automatically in the background.
-    server.queue_alerts(reconcile_messages).await;
-    server.spawn_auto_reattach();
+    // Startup reconcile (one provider round-trip per durable record) runs in
+    // the background: Claude Code gives an MCP server 30 s by default to
+    // answer the handshake, and a single stale record made the reconcile
+    // exceed that, leaving the plugin unavailable for the whole session.
+    // Findings surface via status(); this session's running machines are
+    // picked back up automatically once the reconcile has settled them.
+    let reconcile_server = server.clone();
+    tokio::spawn(async move {
+        let reconcile_messages = reconcile_server.reconcile().await;
+        for message in &reconcile_messages {
+            tracing::info!("{message}");
+        }
+        reconcile_server.queue_alerts(reconcile_messages).await;
+        reconcile_server.spawn_auto_reattach();
+    });
 
     tracing::info!("Starting remote-kernels MCP server");
 

--- a/crates/remote-kernels/src/runtime/runpod.rs
+++ b/crates/remote-kernels/src/runtime/runpod.rs
@@ -509,17 +509,19 @@ impl RunPodRuntime {
     fn ssh_expectation_unmet(&self, ctx: &ConnectionContext) -> anyhow::Error {
         if ctx.fresh {
             anyhow::anyhow!(
-                "No direct SSH endpoint appeared for this pod within {SSH_WAIT_MINUTES} \
-                 minutes. Retry start(). If it keeps happening on community cloud, set \
-                 [runpod] cloud-type = \"SECURE\" in {}.",
+                "No direct SSH endpoint appeared for this pod within {} minutes \
+                 ([runpod] provision-timeout-mins). Retry start(). If it keeps happening \
+                 on community cloud, set [runpod] cloud-type = \"SECURE\" in {}.",
+                self.ssh_wait_minutes(),
                 self.config_path
             )
         } else {
             anyhow::anyhow!(
-                "No direct SSH endpoint appeared for machine {} within {SSH_WAIT_MINUTES} \
-                 minutes. Retry attach(\"{}\"). If it keeps happening, stop() the machine (it \
-                 keeps its data) and tell the user.",
+                "No direct SSH endpoint appeared for machine {} within {} minutes \
+                 ([runpod] provision-timeout-mins). Retry attach(\"{}\"). If it keeps \
+                 happening, stop() the machine (it keeps its data) and tell the user.",
                 ctx.machine_id,
+                self.ssh_wait_minutes(),
                 ctx.machine_id
             )
         }
@@ -701,7 +703,8 @@ impl RunPodRuntime {
     /// `ssh.direct` appears only once the published `22/tcp` mapping has a
     /// public port, which can lag RUNNING by a few seconds.
     async fn wait_for_ssh_info(&self, pod_id: &str) -> anyhow::Result<(String, u16)> {
-        for attempt in 1..=SSH_WAIT_ATTEMPTS {
+        let attempts = self.ssh_wait_minutes() * 60 / SSH_WAIT_INTERVAL.as_secs();
+        for attempt in 1..=attempts {
             match self.client.get_pod(pod_id).await {
                 Ok(pod) => {
                     if let Some((ip, port)) = pod.direct_ssh() {
@@ -714,15 +717,24 @@ impl RunPodRuntime {
             }
             tokio::time::sleep(SSH_WAIT_INTERVAL).await;
         }
-        anyhow::bail!("no direct SSH endpoint after {SSH_WAIT_MINUTES} minutes")
+        anyhow::bail!(
+            "no direct SSH endpoint after {} minutes",
+            self.ssh_wait_minutes()
+        )
+    }
+
+    /// How long `open()` waits for the pod to publish its direct SSH
+    /// endpoint: the configured `provision-timeout-mins`. `RunPod` reports
+    /// RUNNING while the image is still pulling, and a cold pull of a
+    /// 12-16 GB CUDA image takes 2-3 minutes, so a fixed 2-minute wait
+    /// (the value before 0.3.1) failed every cold start of such an image.
+    fn ssh_wait_minutes(&self) -> u64 {
+        self.runpod.provision_timeout_mins.max(1)
     }
 }
 
-/// How long `open()` waits for the pod to publish its direct SSH endpoint,
-/// and the same window in whole minutes for the message that reports it.
-const SSH_WAIT_ATTEMPTS: u64 = 40;
+/// Poll interval for the direct SSH endpoint.
 const SSH_WAIT_INTERVAL: Duration = Duration::from_secs(3);
-const SSH_WAIT_MINUTES: u64 = SSH_WAIT_ATTEMPTS * SSH_WAIT_INTERVAL.as_secs() / 60;
 
 /// Runtime capabilities, exposed credential-free so config validation can
 /// consult them at load time (see [`super::validate_config`]).
@@ -2728,7 +2740,10 @@ mod tests {
 
         let message = secure.ssh_expectation_unmet(&ssh_context(true)).to_string();
         assert!(message.contains("No direct SSH endpoint"), "{message}");
-        assert!(message.contains("2 minutes"), "the window: {message}");
+        assert!(
+            message.contains("20 minutes"),
+            "the window (default provision-timeout-mins): {message}"
+        );
         assert!(message.contains("Retry start()"), "{message}");
         assert!(message.contains("cloud-type = \"SECURE\""), "{message}");
         assert!(message.contains("remote-kernels.toml"), "{message}");

--- a/crates/remote-kernels/src/server.rs
+++ b/crates/remote-kernels/src/server.rs
@@ -25,6 +25,13 @@ use crate::runtime::{
 use crate::state::{AppState, FenceReason, InstanceRecord, InstanceState, KernelRecord, Phase};
 
 const RECORDER_TAIL_BYTES: usize = 1024 * 1024;
+/// How long `start()`/`attach()` wait after Jupyter is up for the on-machine
+/// watchdog to be confirmed before a budgeted machine is given up as
+/// unenforceable and terminated. The wait covers SSH reachability, the lease
+/// acquire and the watchdog install on the machine; 15 s (before 0.3.1) lost
+/// that race on ordinary secure `RunPod` hosts with nothing slow configured.
+const WATCHDOG_CONFIRM_TIMEOUT: std::time::Duration = std::time::Duration::from_mins(2);
+
 const FINALIZE_OP_TIMEOUT_SECS: u64 = 15 * 60;
 
 #[derive(Debug, thiserror::Error)]
@@ -4469,7 +4476,7 @@ impl RemoteKernelsServer {
             // Both the user-visible caveat and the budget enforceability gate
             // consume the same definitive heartbeat event. The timeout is only
             // a backstop for genuinely slow or unreachable transports.
-            let resolved = tokio::time::timeout(std::time::Duration::from_secs(15), async {
+            let resolved = tokio::time::timeout(WATCHDOG_CONFIRM_TIMEOUT, async {
                 while *supervision.borrow() == crate::heartbeat::SupervisionStatus::Pending {
                     if supervision.changed().await.is_err() {
                         break;
@@ -4485,15 +4492,33 @@ impl RemoteKernelsServer {
                 // actionable cause available (e.g. a rejected key file).
                 let cause = match setup_diagnostics.latest() {
                     Some(last) => format!(
-                        "the automatic-shutdown watchdog could not be confirmed within 15 seconds; last error: {last}"
+                        "the automatic-shutdown watchdog could not be confirmed within {} seconds; last error: {last}",
+                        WATCHDOG_CONFIRM_TIMEOUT.as_secs()
                     ),
                     None => {
-                        "the automatic-shutdown watchdog could not be confirmed within 15 seconds"
-                            .to_string()
+                        format!(
+                            "the automatic-shutdown watchdog could not be confirmed within {} seconds",
+                            WATCHDOG_CONFIRM_TIMEOUT.as_secs()
+                        )
                     }
                 };
                 return Err(BudgetUnenforceable(cause).into());
             }
+        }
+        // The watchdog is confirmed; startup commands (bounded to 5 min on
+        // the machine) still have to finish before the machine is handed
+        // over, so that a cell never races an install.
+        if *supervision.borrow() == crate::heartbeat::SupervisionStatus::Supervised
+            && !self.config.startup_commands.is_empty()
+        {
+            let _ = tokio::time::timeout(std::time::Duration::from_mins(6), async {
+                while *supervision.borrow() == crate::heartbeat::SupervisionStatus::Supervised {
+                    if supervision.changed().await.is_err() {
+                        break;
+                    }
+                }
+            })
+            .await;
         }
         let supervision_status = supervision.borrow().clone();
         match supervision_status {
@@ -4508,7 +4533,8 @@ impl RemoteKernelsServer {
                     );
                 }
             }
-            crate::heartbeat::SupervisionStatus::Active => {}
+            crate::heartbeat::SupervisionStatus::Supervised
+            | crate::heartbeat::SupervisionStatus::Active => {}
             crate::heartbeat::SupervisionStatus::Unsupervisable(caveat) => {
                 let waiver = self.budget_source == Some(crate::config::BudgetSource::Toml)
                     && self.config.allow_unenforced_budget_for(&runtime_name);

--- a/crates/remote-kernels/tests/machine_scripts.rs
+++ b/crates/remote-kernels/tests/machine_scripts.rs
@@ -441,16 +441,68 @@ fn enter_finalizing_is_fenced_after_generation_rotation() {
 }
 
 #[test]
-fn acquire_refuses_a_finalizing_lease() {
-    let Some(harness) = Harness::new("acquire_refuses_a_finalizing_lease") else {
+fn acquire_refuses_a_finalizing_lease_while_its_finalizer_is_alive() {
+    let Some(harness) =
+        Harness::new("acquire_refuses_a_finalizing_lease_while_its_finalizer_is_alive")
+    else {
         return;
     };
     harness.lease_ok(&["acquire", "owner-a"]);
     harness.lease_ok(&["arm", "1", "disconnect"]);
     harness.lease_ok(&["enter-finalizing", "1", "op-a", "stop"]);
+    // A stand-in for the detached watchdog: a live process whose command
+    // line names rk-watchdog, recorded in watchdog.pid as the real one is.
+    let mut finalizer = Command::new("/bin/bash")
+        .args(["-c", "exec -a rk-watchdog-stand-in sleep 30"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn stand-in finalizer");
+    fs::write(
+        harness.state_dir().join("watchdog.pid"),
+        format!("{}\n", finalizer.id()),
+    )
+    .expect("write watchdog.pid");
     let output = harness.lease(&["acquire", "owner-b"]);
+    let _ = finalizer.kill();
+    let _ = finalizer.wait();
     assert_eq!(output.status.code(), Some(REFUSED));
     assert_eq!(harness.read_lease()["state"], "finalizing");
+}
+
+#[test]
+fn acquire_reclaims_a_finalizing_lease_whose_finalizer_is_gone() {
+    // The state directory can outlive the machine (a RunPod network volume
+    // mounted at the workdir): a pod that died mid-finalize must not wedge
+    // every later pod as "running its automatic cleanup".
+    let Some(harness) = Harness::new("acquire_reclaims_a_finalizing_lease_whose_finalizer_is_gone")
+    else {
+        return;
+    };
+    harness.lease_ok(&["acquire", "owner-a"]);
+    harness.lease_ok(&["arm", "1", "disconnect"]);
+    harness.lease_ok(&["enter-finalizing", "1", "op-a", "stop"]);
+    fs::write(harness.state_dir().join("outcome.json"), "{}").expect("stale outcome");
+    // No watchdog.pid at all (fresh container) ...
+    let lease = harness.lease_json(&["acquire", "owner-b"]);
+    assert_eq!(lease["state"], "active");
+    assert_eq!(lease["owner_uuid"], "owner-b");
+    assert_eq!(lease["generation"], 2);
+    assert!(!harness.state_dir().join("outcome.json").exists());
+    // ... and a pid file naming a process that no longer exists.
+    harness.lease_ok(&["arm", "2", "disconnect"]);
+    harness.lease_ok(&["enter-finalizing", "2", "op-b", "terminate"]);
+    let mut dead = Command::new("/bin/true").spawn().expect("spawn");
+    let _ = dead.wait();
+    fs::write(
+        harness.state_dir().join("watchdog.pid"),
+        format!("{}\n", dead.id()),
+    )
+    .expect("write watchdog.pid");
+    let lease = harness.lease_json(&["acquire", "owner-c"]);
+    assert_eq!(lease["state"], "active");
+    assert_eq!(lease["owner_uuid"], "owner-c");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #97, #98, #99, #100 — four provisioning defects seen over two days of RunPod use with a network volume (secure cloud, EU-RO-1). Each was confirmed against the v0.3.0 source and live pods; the evidence is in the issues.

## Changes

- **SSH wait honours `[runpod] provision-timeout-mins`** (`runtime/runpod.rs`). It was a fixed 40 × 3 s, entered as soon as RunPod reports RUNNING, which it does while the image is still pulling; a cold pull of a 12–16 GB CUDA image takes 2–3 min, so every fresh `start()` of such an image failed and the pod was terminated. The poll still returns the moment the endpoint appears. Error messages name the knob.
- **Watchdog confirmation gate 15 s → 2 min, and startup commands run after the watchdog is installed** (`server.rs`, `heartbeat.rs`). The gate had to fit SSH reachability, lease acquire, `startup-commands` and the watchdog install; volume forensics showed the install landing 4–5 s after the gate had expired, and even a 1 s startup command lost the race on ordinary hosts. A new `SupervisionStatus::Supervised` marks "watchdog confirmed, startup commands running" so `start()` still waits for the commands (bounded as before) without them gating budget enforceability.
- **`rk-lease.sh acquire` reclaims a finalizing lease whose finalizer is not alive on this machine** (checked via `watchdog.pid`: process alive and its command line names `rk-watchdog`). The state dir is `<workdir>/.remote-kernels`, and on RunPod the workdir is the network volume, so a pod that died mid-finalize left a `finalizing` lease that every later pod inherited as "machine is running its automatic cleanup" — refusing stop/terminate/attach on a brand-new pod while it billed. The stale outcome marker is dropped with it. A finalizer that *is* alive is still refused (test kept, with a stand-in process).
- **Startup reconcile runs in a background task** (`main.rs`) instead of before `serve()`. One stale record (pod stopped elsewhere) made the reconcile exceed Claude Code's 30 s MCP connect timeout, leaving the plugin unavailable for whole sessions.

## Tests

`cargo test -p remote-kernels`: 203 unit + 27 fake e2e + machine-script tests pass; `machine_scripts.rs` gains `acquire_refuses_a_finalizing_lease_while_its_finalizer_is_alive` and `acquire_reclaims_a_finalizing_lease_whose_finalizer_is_gone`; the SSH-window assertion follows the default provision timeout. `cargo clippy --all-targets -D warnings` and `cargo fmt --check` clean. Not run: the credentialed RunPod/vast/k8s e2e suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
